### PR TITLE
Feature/#10 이미지 삭제 로직

### DIFF
--- a/get_animals_info.py
+++ b/get_animals_info.py
@@ -10,6 +10,7 @@ from pprint import pprint
 import pymysql
 import pandas as pd
 from utils.querys import make_query_insert, make_query_truncate
+from utils.image_pipeline import image_pipeline
 
 def get_url(API_Key, date, page_number = 1):
     dog_code = 417000
@@ -79,30 +80,6 @@ def post_data(query_insert, data):
     finally:
         db.close()
     print(f"post_data elapsed time : {time.time() - start}\n")
-    
-def save_images(IMG_PATH, previous_images, current_images, df):
-    create_images = current_images - previous_images
-    current_images_json = df[df["desertionNo"].isin(create_images)][["desertionNo","popfile"]].to_dict("records")
-
-    for item_dict in tqdm(current_images_json):
-        responds = requests.get(item_dict['popfile'])
-        open(f"{IMG_PATH}/{item_dict['desertionNo']}.jpg", "wb").write(responds.content)
-    # return
-
-def remove_images(IMG_PATH, previous_images, current_images):
-    delete_images = previous_images - current_images
-    print(delete_images)
-    for desertionNo in delete_images:
-        print(desertionNo)
-        os.remove(f"{IMG_PATH}/{desertionNo}.jpg")
-
-def image_pipeline(IMG_PATH, df):
-    os.makedirs(IMG_PATH, exist_ok=True)
-    previous_images = set([os.path.splitext(os.path.basename(path))[0] for path in os.listdir(IMG_PATH)])
-    current_images = set(df["desertionNo"].to_list())
-    
-    save_images(IMG_PATH, previous_images, current_images, df)
-    remove_images(IMG_PATH, previous_images, current_images)
     
 def main():
     IMG_PATH = "./images/announcement"

--- a/utils/image_pipeline.py
+++ b/utils/image_pipeline.py
@@ -1,0 +1,25 @@
+import os
+import requests
+from tqdm import tqdm
+
+def save_images(IMG_PATH, previous_images, current_images, df):
+    create_images = current_images - previous_images
+    current_images_json = df[df["desertionNo"].isin(create_images)][["desertionNo","popfile"]].to_dict("records")
+
+    for item_dict in tqdm(current_images_json):
+        responds = requests.get(item_dict['popfile'])
+        open(f"{IMG_PATH}/{item_dict['desertionNo']}.jpg", "wb").write(responds.content)
+    # return
+
+def remove_images(IMG_PATH, previous_images, current_images):
+    delete_images = previous_images - current_images
+    for desertionNo in delete_images:
+        os.remove(f"{IMG_PATH}/{desertionNo}.jpg")
+
+def image_pipeline(df, IMG_PATH):
+    os.makedirs(IMG_PATH, exist_ok=True)
+    previous_images = set([os.path.splitext(os.path.basename(path))[0] for path in os.listdir(IMG_PATH)])
+    current_images = set(df["desertionNo"].to_list())
+    
+    save_images(IMG_PATH, previous_images, current_images, df)
+    remove_images(IMG_PATH, previous_images, current_images)


### PR DESCRIPTION
- 필요성 : 이미 GCP 인스턴스 30GB 중 15GB 정도 사용 중
- 구현 방법 : 기존에 있는 파일 목록 집합에서 새로운 파일 목록 집합을 차집합 합니다. 그러면 남는 건 삭제해야할 목록입니다. 이를 대상으로 매 주기마다 삭제를 진행합니다.

<img width="359" alt="image" src="https://user-images.githubusercontent.com/20448972/196842361-5a4b865d-2062-4c60-95d7-35eb824b06a7.png">

- AI가 실행 중일 때 사진이 삭제 되면 어떻게 되나 싶은데 현재 기준으로 필요없는 사진이라 앞으로 작업할 필요가 없습니다.
- 만약 AI가 파일 목록을 부르고 for문이 실행되고 있을 때 삭제되면 어떻게 되나 싶은데 평균 약 2,000장이며 [인철님 말씀](https://discord.com/channels/1021309073184014356/1028671864316362903/1031746250598535228)에 따르면 500장에 2분 정도니 산술적으로 8분 정도 밖에 걸리지 않습니다. 

(DB에 저장하는 파이프라인은 약 5초 내외이고 사진저장은 증분으로 처리하여 1시간 주기 많아봐야 몇십장 정도니 10분 정도면 충분합니다. 삭제는 비슷한 수량에 더 빠르구요. 인스턴스 사양에 따라 다르지만 총합 20~30분 정도 걸리는 시간이겠네요.)
 